### PR TITLE
Add CryptoPro HSM channel support

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -1095,7 +1095,7 @@ NOEXPORT void ssl_start(CLI *c) {
             throw_exception( c, 1 );
         }
 
-        if( c->opt->option.client && !c->opt->option.session_resume )
+        if( !c->opt->option.session_resume )
         {
             int cache_id;
 #ifdef USE_OS_THREADS

--- a/src/client.c
+++ b/src/client.c
@@ -38,6 +38,117 @@
 #include "common.h"
 #include "prototypes.h"
 
+#ifdef MSSPI_LINUX
+#include <dlfcn.h>
+#include <stdint.h>
+
+#if defined(__mips__)
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define CPRO_LIBDIR "/opt/cprocsp/lib/mipsel/"
+#else
+#define CPRO_LIBDIR "/opt/cprocsp/lib/mips/"
+#endif
+#elif defined(__arm__)
+#define CPRO_LIBDIR "/opt/cprocsp/lib/arm/"
+#elif defined(__aarch64__)
+#define CPRO_LIBDIR "/opt/cprocsp/lib/aarch64/"
+#elif defined(__e2k__) || defined(__PPC64__)
+#define CPRO_LIBDIR "/opt/cprocsp/lib/lib64/"
+#elif defined(__i386__)
+#define CPRO_LIBDIR "/opt/cprocsp/lib/ia32/"
+#else
+#define CPRO_LIBDIR "/opt/cprocsp/lib/amd64/"
+#endif
+
+#define LIBCSPR_NAME "libcspr.so"
+#define LIBCSPR_PATH CPRO_LIBDIR LIBCSPR_NAME
+
+typedef uint32_t (*WIRE_SEND)(int);
+typedef uint32_t (*WIRE_RECV)(int, uid_t *, gid_t *);
+
+static WIRE_SEND wire_send;
+static WIRE_RECV wire_recv;
+static int wire_loaded;
+
+NOEXPORT void wire_load(void) {
+    void *lib;
+    const char *error;
+
+    lib=dlopen(LIBCSPR_PATH, RTLD_LAZY | RTLD_LOCAL);
+    if(!lib)
+        lib=dlopen(LIBCSPR_NAME, RTLD_LAZY | RTLD_LOCAL);
+    if(!lib) {
+        error=dlerror();
+        s_log(LOG_ERR, "for_hsm: unable to load %s: %s",
+            LIBCSPR_NAME, error ? error : "unknown error");
+        return;
+    }
+
+    dlerror();
+    *(void **)&wire_send=dlsym(lib, "WireSendFDnEUID");
+    error=dlerror();
+    if(error || !wire_send) {
+        s_log(LOG_ERR, "for_hsm: WireSendFDnEUID is unavailable: %s",
+            error ? error : "symbol not found");
+        return;
+    }
+
+    dlerror();
+    *(void **)&wire_recv=dlsym(lib, "WireRecvFDnEUID");
+    error=dlerror();
+    if(error || !wire_recv) {
+        s_log(LOG_ERR, "for_hsm: WireRecvFDnEUID is unavailable: %s",
+            error ? error : "symbol not found");
+        return;
+    }
+
+    wire_loaded=1;
+}
+
+NOEXPORT int wire_load_once(void) {
+#ifdef USE_PTHREAD
+    static pthread_once_t once=PTHREAD_ONCE_INIT;
+
+    if(pthread_once(&once, wire_load)) {
+        s_log(LOG_ERR, "for_hsm: pthread_once failed");
+        return 0;
+    }
+#else
+    static int initialized;
+
+    if(!initialized) {
+        wire_load();
+        initialized=1;
+    }
+#endif
+    return wire_loaded;
+}
+
+NOEXPORT int wire_send_credentials(SOCKET fd) {
+    uint32_t result;
+
+    if(!wire_load_once())
+        return 0;
+    result=wire_send((int)fd);
+    if(result)
+        s_log(LOG_ERR, "for_hsm: WireSendFDnEUID failed: 0x%08x",
+            (unsigned)result);
+    return result==0;
+}
+
+NOEXPORT int wire_receive_credentials(SOCKET fd, uid_t *uid, gid_t *gid) {
+    uint32_t result;
+
+    if(!wire_load_once())
+        return 0;
+    result=wire_recv((int)fd, uid, gid);
+    if(result)
+        s_log(LOG_ERR, "for_hsm: WireRecvFDnEUID failed: 0x%08x",
+            (unsigned)result);
+    return result==0;
+}
+#endif /* MSSPI_LINUX */
+
 #ifdef MSSPISSL
 #ifdef NO_OPENSSLOFF
 #else /* NO_OPENSSLOFF */
@@ -816,6 +927,20 @@ NOEXPORT void local_start(CLI *c) {
         return;
     }
 
+#if defined(MSSPI_LINUX) && defined(HAVE_STRUCT_SOCKADDR_UN)
+    if(c->opt->option.for_hsm && !c->is_exec &&
+            c->peer_addr.sa.sa_family==AF_UNIX) {
+        uid_t uid;
+        gid_t gid;
+
+        if(!wire_receive_credentials(c->local_rfd.is_socket ?
+                c->local_rfd.fd : c->local_wfd.fd, &uid, &gid))
+            throw_exception(c, 1);
+        s_log(LOG_DEBUG, "for_hsm: received Unix credentials uid=%ld gid=%ld",
+            (long)uid, (long)gid);
+    }
+#endif
+
     /* authenticate based on retrieved IP address of the client */
     c->accepted_address=s_ntop(&c->peer_addr, c->peer_addr_len);
 #ifdef USE_LIBWRAP
@@ -1212,6 +1337,15 @@ NOEXPORT void ssl_start(CLI *c) {
 
         if( c->opt->option.client )
             msspi_set_client( c->msh, 1 );
+
+#ifdef MSSPI_LINUX
+        if( c->opt->option.for_hsm &&
+                !msspi_set_verify_revocation( c->msh, 0 ) )
+        {
+            s_log( LOG_ERR, "for_hsm: failed to disable revocation checks" );
+            throw_exception( c, 1 );
+        }
+#endif
 
         if( c->opt->cipher_list )
             msspi_set_cipherlist( c->msh, (const uint8_t *)c->opt->cipher_list, strlen( c->opt->cipher_list ) );
@@ -2424,6 +2558,12 @@ NOEXPORT SOCKET connect_remote(CLI *c) {
                 !s_connect(c, &c->connect_addr.addr[c->idx],
                     addr_len(&c->connect_addr.addr[c->idx]),
                     c->opt->timeout_connect)) {
+#if defined(MSSPI_LINUX) && defined(HAVE_STRUCT_SOCKADDR_UN)
+            if(c->opt->option.for_hsm &&
+                    c->connect_addr.addr[c->idx].sa.sa_family==AF_UNIX &&
+                    !wire_send_credentials(c->fd))
+                throw_exception(c, 1);
+#endif
 #ifdef NO_OPENSSLOFF
             if(c->ssl) {
                 SSL_SESSION *sess=SSL_get1_session(c->ssl);

--- a/src/client.c
+++ b/src/client.c
@@ -124,6 +124,90 @@ const char * SSL_get_version_msspi( MSSPI_HANDLE h )
     return (const char *)version_string;
 }
 
+#ifdef MSSPI_LINUX
+#include <semaphore.h>
+#include <errno.h>
+static sem_t msspi_gate;
+static int msspi_gate_on = 0;
+void msspi_gate_init( long parallel )
+{
+    static int done = 0;
+    const char * e;
+    long n = parallel;
+    if( done )
+        return;
+    done = 1;
+    e = getenv( "STUNNEL_CRYPTO_PARALLEL" );
+    if( e && *e )
+    {
+        char * end;
+        long v = strtol( e, &end, 10 );
+        if( end != e && *end == '\0' && v >= 0 )
+            n = v;
+    }
+    if( n > 0 && sem_init( &msspi_gate, 0, ( unsigned )n ) == 0 )
+        msspi_gate_on = 1;
+}
+NOEXPORT void msspi_gate_enter( void )
+{
+    if( msspi_gate_on )
+        while( sem_wait( &msspi_gate ) == -1 && errno == EINTR )
+            ;
+}
+NOEXPORT void msspi_gate_leave( void )
+{
+    if( msspi_gate_on )
+        sem_post( &msspi_gate );
+}
+int msspi_gate_connect( CLI * c )
+{
+    int ret;
+    msspi_gate_enter();
+    ret = msspi_connect( c->msh );
+    msspi_gate_leave();
+    return ret;
+}
+int msspi_gate_accept( CLI * c )
+{
+    int ret;
+    msspi_gate_enter();
+    ret = msspi_accept( c->msh );
+    msspi_gate_leave();
+    return ret;
+}
+int msspi_gate_read( CLI * c, void * buf, int len )
+{
+    int ret;
+    msspi_gate_enter();
+    ret = msspi_read( c->msh, buf, len );
+    msspi_gate_leave();
+    return ret;
+}
+int msspi_gate_write( CLI * c, const void * buf, int len )
+{
+    int ret;
+    msspi_gate_enter();
+    ret = msspi_write( c->msh, buf, len );
+    msspi_gate_leave();
+    return ret;
+}
+int msspi_gate_shutdown( CLI * c )
+{
+    int ret;
+    msspi_gate_enter();
+    ret = msspi_shutdown( c->msh );
+    msspi_gate_leave();
+    return ret;
+}
+void msspi_gate_close( CLI * c )
+{
+    msspi_gate_enter();
+    msspi_close( c->msh );
+    c->msh = NULL;
+    msspi_gate_leave();
+}
+#endif /* MSSPI_LINUX */
+
 int BIO_sock_non_fatal_error( int err )
 {
     switch( err )
@@ -567,9 +651,14 @@ NOEXPORT void client_run(CLI *c) {
 #ifdef MSSPISSL
     if( c->msh )
     {
+#ifdef MSSPI_LINUX
+        msspi_gate_shutdown( c );
+        msspi_gate_close( c );
+#else
         msspi_shutdown( c->msh );
         msspi_close( c->msh );
         c->msh = NULL;
+#endif
     }
 
     if( c->exec_fd != INVALID_SOCKET )

--- a/src/common.h
+++ b/src/common.h
@@ -43,6 +43,10 @@
 #define USE_OS_THREADS
 typedef void CRYPTO_RWLOCK;
 
+#if defined(MSSPISSL) && defined(__linux__)
+#define MSSPI_LINUX
+#endif
+
 #include "version.h"
 
 /**************************************** common constants */

--- a/src/options.c
+++ b/src/options.c
@@ -2051,6 +2051,40 @@ NOEXPORT const char *parse_service_option(CMD cmd, SERVICE_OPTIONS **section_ptr
         break;
     }
 
+#ifdef MSSPI_LINUX
+    /* for_hsm */
+    switch(cmd) {
+    case CMD_SET_DEFAULTS:
+        section->option.for_hsm=0;
+        break;
+    case CMD_SET_COPY:
+        section->option.for_hsm=new_service_options.option.for_hsm;
+        break;
+    case CMD_FREE:
+        break;
+    case CMD_SET_VALUE:
+        if(strcasecmp(opt, "for_hsm"))
+            break;
+        if(!strcasecmp(arg, "yes"))
+            section->option.for_hsm=1;
+        else if(!strcasecmp(arg, "no"))
+            section->option.for_hsm=0;
+        else
+            return "The argument needs to be either 'yes' or 'no'";
+        return NULL; /* OK */
+    case CMD_INITIALIZE:
+        break;
+    case CMD_PRINT_DEFAULTS:
+        s_log(LOG_NOTICE, "%-22s = no", "for_hsm");
+        break;
+    case CMD_PRINT_HELP:
+        s_log(LOG_NOTICE,
+            "%-22s = yes|no enable CryptoPro HSM Unix credential handshake",
+            "for_hsm");
+        break;
+    }
+#endif /* MSSPI_LINUX */
+
     /* pin */
     switch( cmd )
     {

--- a/src/options.c
+++ b/src/options.c
@@ -1325,6 +1325,40 @@ NOEXPORT const char *parse_global_option(CMD cmd, GLOBAL_OPTIONS *options, char 
         break;
     }
 
+#ifdef MSSPI_LINUX
+    /* cryptoParallel */
+    switch(cmd) {
+    case CMD_SET_DEFAULTS:
+        options->crypto_parallel=0;
+        break;
+    case CMD_SET_COPY: /* not used for global options */
+        break;
+    case CMD_FREE:
+        break;
+    case CMD_SET_VALUE:
+        if(strcasecmp(opt, "cryptoParallel"))
+            break;
+        {
+            char *tmp_str;
+            long v=strtol(arg, &tmp_str, 10);
+            if(tmp_str==arg || *tmp_str || v<0)
+                return "cryptoParallel must be 0 (off) or a positive integer";
+            options->crypto_parallel=(int)v;
+        }
+        return NULL; /* OK */
+    case CMD_INITIALIZE:
+        msspi_gate_init(options->crypto_parallel);
+        break;
+    case CMD_PRINT_DEFAULTS:
+        s_log(LOG_NOTICE, "%-22s = 0", "cryptoParallel");
+        break;
+    case CMD_PRINT_HELP:
+        s_log(LOG_NOTICE, "%-22s = max concurrent CryptoPro CSP operations, 0=off",
+            "cryptoParallel");
+        break;
+    }
+#endif /* MSSPI_LINUX */
+
     /* RNDfile */
     switch(cmd) {
     case CMD_SET_DEFAULTS:

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -418,6 +418,9 @@ struct service_options_struct {
     struct {
 #ifdef MSSPISSL
         unsigned msspi:1;               /* use msspi */
+#ifdef MSSPI_LINUX
+        unsigned for_hsm:1;             /* CryptoPro HSM Unix credential handshake */
+#endif
         unsigned silent:1;
         unsigned selftest:1;
 #endif

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -211,6 +211,9 @@ struct global_options_struct {
     char *egd_sock;                       /* entropy gathering daemon socket */
     char *rand_file;                                /* file with random data */
     long random_bytes;                      /* how many random bytes to read */
+#ifdef MSSPI_LINUX
+    int crypto_parallel;
+#endif
 
         /* some global data for stunnel.c */
 #ifndef USE_WIN32
@@ -1034,6 +1037,33 @@ ICON_IMAGE load_icon_file(const char *);
 #endif
 
 #ifdef MSSPISSL
+#ifdef MSSPI_LINUX
+void msspi_gate_init( long );
+int msspi_gate_connect( CLI * );
+int msspi_gate_accept( CLI * );
+int msspi_gate_read( CLI *, void *, int );
+int msspi_gate_write( CLI *, const void *, int );
+int msspi_gate_shutdown( CLI * );
+void msspi_gate_close( CLI * );
+
+#undef SSL_connect
+#define SSL_connect( s ) msspi_gate_connect( c )
+
+#undef SSL_accept
+#define SSL_accept( s ) msspi_gate_accept( c )
+
+#undef SSL_write
+#define SSL_write( s, b, n ) msspi_gate_write( c, b, n )
+
+#undef SSL_read
+#define SSL_read( s, b, n ) msspi_gate_read( c, b, n )
+
+#undef SSL_shutdown
+#define SSL_shutdown( s ) msspi_gate_shutdown( c )
+
+#undef SSL_set_shutdown
+#define SSL_set_shutdown( s, m ) { if( (m) & SSL_SENT_SHUTDOWN ) msspi_gate_shutdown( c ); }
+#else
 #undef SSL_connect
 #define SSL_connect( s ) msspi_connect( c->msh )
 
@@ -1054,6 +1084,7 @@ ICON_IMAGE load_icon_file(const char *);
 
 #undef SSL_set_shutdown
 #define SSL_set_shutdown( s, m ) { if( (m) & SSL_SENT_SHUTDOWN ) msspi_shutdown( c->msh ); }
+#endif /* MSSPI_LINUX */
 
 int SSL_get_shutdown_msspi( MSSPI_HANDLE h );
 #undef SSL_get_shutdown


### PR DESCRIPTION
## Summary

- update the MSSPI submodule to 1.0.8 and apply session cache IDs to both client and server sessions
- add the Linux-only `cryptoParallel` option to limit concurrent CryptoPro operations
- add the Linux-only `for_hsm` mode with delayed loading of `WireSendFDnEUID` and `WireRecvFDnEUID`
- disable certificate revocation checks for HSM channels while preserving normal MSSPI verification
- use a shared `MSSPI_LINUX` compile-time guard for Linux-specific MSSPI functionality

## Validation

- clean Linux MSSPI build
- strict certificate verification with SNI against the HSM endpoint
- CryptoPro `csptest` completed successfully through the tunnel
- DGTRY `TestSign` completed successfully for both MVP and HSM providers
