### PR TITLE
Support Windows Vista and Windows 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         files: src/${{ steps.build.outputs.VERSION }}.tar.gz
 
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     name: CI (windows)
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,12 @@ jobs:
         BUILD_TAG: ${{ github.ref_name }}
       run: build_win.bat
 
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows
+        path: "${{ github.ref_name }}-*-windows.zip"
+
     - name: Release
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')

--- a/build_win.bat
+++ b/build_win.bat
@@ -38,7 +38,7 @@ echo.
 echo ========== Building x86 ==========
 echo.
 
-call "%VCVARSALL%" x86 || exit /b 1
+call "%VCVARSALL%" x86 -vcvars_ver=14.29 || exit /b 1
 
 7z x bin32.zip -aoa
 copy /y bin32\opensslconf.h %OPENSSL_INCLUDE%\openssl\opensslconf.h >nul
@@ -63,7 +63,7 @@ echo.
 echo ========== Building x64 ==========
 echo.
 
-call "%VCVARSALL%" x64 || exit /b 1
+call "%VCVARSALL%" x64 -vcvars_ver=14.29 || exit /b 1
 
 7z x bin64.zip -aoa
 copy /y bin64\opensslconf.h %OPENSSL_INCLUDE%\openssl\opensslconf.h >nul

--- a/build_win.bat
+++ b/build_win.bat
@@ -17,8 +17,9 @@ if not exist %OPENSSL_INCLUDE%\ms mkdir %OPENSSL_INCLUDE%\ms
 curl -fsSL -o %OPENSSL_INCLUDE%\ms\applink.c https://raw.githubusercontent.com/deemru/openssl/%OPENSSL_VERSION%/ms/applink.c || exit /b 1
 
 set INCLUDES=/I%OPENSSL_INCLUDE% /I./src/msspi/third_party/cprocsp/include
-set CFLAGS_CPP=/c /Ox /Os /GL /GF /GS- /Wall /EHa /DMSSPI_USE_MSSPI_CERT %INCLUDES%
-set CFLAGS_C=/c /Ox /Os /GL /GF /GS- /W4 /DUSE_MSSPI /DMSSPI_USE_MSSPI_CERT %INCLUDES%
+set WINDOWS_TARGET=/DWINVER=0x0600 /D_WIN32_WINNT=0x0600
+set CFLAGS_CPP=/c /Ox /Os /GL /GF /GS- /Wall /EHa %WINDOWS_TARGET% /DMSSPI_USE_MSSPI_CERT %INCLUDES%
+set CFLAGS_C=/c /Ox /Os /GL /GF /GS- /W4 %WINDOWS_TARGET% /DUSE_MSSPI /DMSSPI_USE_MSSPI_CERT %INCLUDES%
 set LIBS=crypt32.lib advapi32.lib ws2_32.lib shell32.lib user32.lib gdi32.lib comdlg32.lib
 
 set SRC_CPP=src/msspi/src/msspi.cpp
@@ -51,7 +52,7 @@ pushd src
 rc -r resources.rc || exit /b 1
 popd
 
-link /LTCG %OBJS% %LIBS% ./src/resources.res /subsystem:windows /OUT:stunnel-msspi.exe || exit /b 1
+link /LTCG %OBJS% %LIBS% ./src/resources.res /subsystem:windows,6.00 /OUT:stunnel-msspi.exe || exit /b 1
 
 if defined BUILD_TAG (
     7z a %BUILD_TAG%-386-windows.zip stunnel-msspi.exe || exit /b 1
@@ -76,7 +77,7 @@ pushd src
 rc -r resources.rc || exit /b 1
 popd
 
-link /LTCG %OBJS% %LIBS% ./src/resources.res /subsystem:windows /OUT:stunnel-msspi.exe || exit /b 1
+link /LTCG %OBJS% %LIBS% ./src/resources.res /subsystem:windows,6.00 /OUT:stunnel-msspi.exe || exit /b 1
 
 if defined BUILD_TAG (
     7z a %BUILD_TAG%-amd64-windows.zip stunnel-msspi.exe || exit /b 1

--- a/src/client.c
+++ b/src/client.c
@@ -1336,8 +1336,13 @@ NOEXPORT void ssl_start(CLI *c) {
         if( c->opt->cipher_list )
             msspi_set_cipherlist( c->msh, (const uint8_t *)c->opt->cipher_list, strlen( c->opt->cipher_list ) );
 
-        if( c->opt->option.client )
-            msspi_set_cert_cb( c->msh, stunnel_msspi_cert_cb );
+        if( c->opt->option.client ) {
+            if( msspi_cert_cb_supported ||
+                    !( c->opt->option.verify_chain || c->opt->option.verify_peer ) )
+                msspi_set_cert_cb( c->msh, stunnel_msspi_cert_cb );
+            else if( !msspi_load_own_certs( c ) )
+                throw_exception( c, 1 );
+        }
         else if( !msspi_load_own_certs( c ) )
             throw_exception( c, 1 );
     }

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -541,6 +541,10 @@ typedef enum {
     RENEG_DETECTED /* renegotiation detected */
 } RENEG_STATE;
 
+#ifdef MSSPISSL
+extern int msspi_cert_cb_supported;
+#endif
+
 struct client_data_struct {
 #ifdef MSSPISSL
     MSSPI_HANDLE msh;

--- a/src/stunnel.c
+++ b/src/stunnel.c
@@ -102,6 +102,9 @@ int num_clients=-1;
 s_poll_set *fds; /* file descriptors of listening sockets */
 int systemd_fds; /* number of file descriptors passed by systemd */
 int listen_fds_start; /* base for systemd-provided file descriptors */
+#ifdef MSSPISSL
+int msspi_cert_cb_supported=1;
+#endif
 
 /**************************************** startup */
 
@@ -109,6 +112,10 @@ int listen_fds_start; /* base for systemd-provided file descriptors */
 int stunnel_init(void) { /* basic initialization */
 #ifdef USE_WIN32
     static struct WSAData wsa_state;
+#ifdef MSSPISSL
+    DWORD version;
+    int major, minor;
+#endif
 #endif
 
     tls_init(); /* initialize thread-local storage */
@@ -117,6 +124,15 @@ int stunnel_init(void) { /* basic initialization */
     crypto_init(); /* initialize libcrypto */
 #endif /* NO_OPENSSLOFF */
 #ifdef USE_WIN32
+#ifdef MSSPISSL
+#ifdef _MSC_VER
+#pragma warning(disable: 4996)
+#endif
+    version=GetVersion();
+    major=LOBYTE(LOWORD(version));
+    minor=HIBYTE(LOWORD(version));
+    msspi_cert_cb_supported=major>6 || (major==6 && minor>=2);
+#endif
     if(WSAStartup(MAKEWORD(2, 2), &wsa_state))
         return 1; /* error */
 #endif


### PR DESCRIPTION
## Summary

- target Windows Vista (`WINVER` and `_WIN32_WINNT` 0x0600, subsystem 6.00)
- use the Visual Studio 2019 v142 toolset to avoid Windows 8-only runtime imports
- load the client certificate before the handshake on pre-Windows 8 systems when peer verification is enabled
- upload Windows build artifacts for branch builds

## Validation

- Windows x86 and x64 builds completed successfully
- both binaries use subsystem 6.0 and do not import `GetSystemTimePreciseAsFileTime` or other APIs newer than Vista

Windows build: https://github.com/PiDmitrius/stunnel-msspi/actions/runs/29687534168