### PR TITLE
Use certificate callback on all supported Windows versions

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -1336,13 +1336,8 @@ NOEXPORT void ssl_start(CLI *c) {
         if( c->opt->cipher_list )
             msspi_set_cipherlist( c->msh, (const uint8_t *)c->opt->cipher_list, strlen( c->opt->cipher_list ) );
 
-        if( c->opt->option.client ) {
-            if( msspi_cert_cb_supported ||
-                    !( c->opt->option.verify_chain || c->opt->option.verify_peer ) )
-                msspi_set_cert_cb( c->msh, stunnel_msspi_cert_cb );
-            else if( !msspi_load_own_certs( c ) )
-                throw_exception( c, 1 );
-        }
+        if( c->opt->option.client )
+            msspi_set_cert_cb( c->msh, stunnel_msspi_cert_cb );
         else if( !msspi_load_own_certs( c ) )
             throw_exception( c, 1 );
     }

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -541,10 +541,6 @@ typedef enum {
     RENEG_DETECTED /* renegotiation detected */
 } RENEG_STATE;
 
-#ifdef MSSPISSL
-extern int msspi_cert_cb_supported;
-#endif
-
 struct client_data_struct {
 #ifdef MSSPISSL
     MSSPI_HANDLE msh;

--- a/src/stunnel.c
+++ b/src/stunnel.c
@@ -102,20 +102,12 @@ int num_clients=-1;
 s_poll_set *fds; /* file descriptors of listening sockets */
 int systemd_fds; /* number of file descriptors passed by systemd */
 int listen_fds_start; /* base for systemd-provided file descriptors */
-#ifdef MSSPISSL
-int msspi_cert_cb_supported=1;
-#endif
-
 /**************************************** startup */
 
 /* this has to be the first function called from ui_*.c */
 int stunnel_init(void) { /* basic initialization */
 #ifdef USE_WIN32
     static struct WSAData wsa_state;
-#ifdef MSSPISSL
-    DWORD version;
-    int major, minor;
-#endif
 #endif
 
     tls_init(); /* initialize thread-local storage */
@@ -124,15 +116,6 @@ int stunnel_init(void) { /* basic initialization */
     crypto_init(); /* initialize libcrypto */
 #endif /* NO_OPENSSLOFF */
 #ifdef USE_WIN32
-#ifdef MSSPISSL
-#ifdef _MSC_VER
-#pragma warning(disable: 4996)
-#endif
-    version=GetVersion();
-    major=LOBYTE(LOWORD(version));
-    minor=HIBYTE(LOWORD(version));
-    msspi_cert_cb_supported=major>6 || (major==6 && minor>=2);
-#endif
     if(WSAStartup(MAKEWORD(2, 2), &wsa_state))
         return 1; /* error */
 #endif


### PR DESCRIPTION
## Summary

- use the MSSPI certificate callback uniformly on every supported Windows version
- remove the pre-Windows 8 client certificate fallback and Windows version detection

The certificate chain is now available through the callback on legacy Windows systems.